### PR TITLE
Rename Check#errors and Check#warnings

### DIFF
--- a/db/migrate/20170404125450_rename_check_warnings_and_errors.rb
+++ b/db/migrate/20170404125450_rename_check_warnings_and_errors.rb
@@ -1,0 +1,6 @@
+class RenameCheckWarningsAndErrors < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :checks, :errors, :link_errors
+    rename_column :checks, :warnings, :link_warnings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170403160309) do
+ActiveRecord::Schema.define(version: 20170404125450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,10 +18,10 @@ ActiveRecord::Schema.define(version: 20170403160309) do
   create_table "checks", force: :cascade do |t|
     t.datetime "started_at"
     t.datetime "ended_at"
-    t.json     "warnings"
-    t.json     "errors"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.json     "link_warnings"
+    t.json     "link_errors"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   create_table "jobs", force: :cascade do |t|

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :check do
     started_at "2017-04-03 15:36:31"
     ended_at "2017-04-03 15:36:35"
-    warnings ""
-    errors ""
+    link_warnings ""
+    link_errors ""
   end
 end


### PR DESCRIPTION
ActiveRecord doesn't want us to overload the `errors` attribute in our
models, funny that. So rename the warnings and errors fields to something
that doesn't collide with fields used for Rails validations.